### PR TITLE
Encapsulate names with spaces with quotes

### DIFF
--- a/src/main/java/org/quiltmc/json5/JsonWriter.java
+++ b/src/main/java/org/quiltmc/json5/JsonWriter.java
@@ -351,6 +351,9 @@ public final class JsonWriter implements Closeable, Flushable {
 		if (stackSize == 0) {
 			throw new IllegalStateException("JsonWriter is closed.");
 		}
+		if (name.contains(" ")) {
+			name = '"' + name + '"';
+		}
 		deferredName = name;
 		return this;
 	}

--- a/src/main/java/org/quiltmc/json5/JsonWriter.java
+++ b/src/main/java/org/quiltmc/json5/JsonWriter.java
@@ -351,9 +351,6 @@ public final class JsonWriter implements Closeable, Flushable {
 		if (stackSize == 0) {
 			throw new IllegalStateException("JsonWriter is closed.");
 		}
-		if (name.contains(" ")) {
-			name = '"' + name + '"';
-		}
 		deferredName = name;
 		return this;
 	}
@@ -650,7 +647,7 @@ public final class JsonWriter implements Closeable, Flushable {
 	private void writeDeferredName() throws IOException {
 		if (deferredName != null) {
 			beforeName();
-			string(deferredName, strict, true);
+			string(deferredName, strict || deferredName.contains(" "), true);
 			deferredName = null;
 		}
 	}

--- a/src/test/java/org/quiltmc/json5/test/WriteTests.java
+++ b/src/test/java/org/quiltmc/json5/test/WriteTests.java
@@ -105,6 +105,7 @@ class WriteTests {
 					.comment("Surprise! Another value approaches!")
 					.name("another_value").value("chicken nuggets")
 					.comment("Wow this sure is a lot of comments huh")
+					.name("test name with spaces").value(0L)
 				.endObject()
 				.comment("Glad that's over.");
 	}


### PR DESCRIPTION
json5 supports quoted names for object keys with spaces, and this PR adds support for that functionality to quilt-json5.